### PR TITLE
Security: Pin GitHub Actions to full commit hashes

### DIFF
--- a/.github/workflows/secure-workflows.yml
+++ b/.github/workflows/secure-workflows.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # was: actions/checkout@v4
         with:
           fetch-depth: 0  # Needed to create PRs
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # was: actions/checkout@v4
       
       - name: Setup
         run: |
@@ -70,7 +70,7 @@ jobs:
           fi
         
       - name: Upload scan results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # was: actions/upload-artifact@v4
         with:
           name: security-scan-results
           path: scan-results/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # was: actions/checkout@v4
       
       - name: Setup test environment
         run: |


### PR DESCRIPTION
# GitHub Actions Security Update
\nThis PR updates GitHub Actions from tags/branches to full commit hashes for improved security.\n
## Changes Made\n
| File | Original Reference | Pinned Commit | Validation Links |
|------|-------------------|--------------|-----------------|
\nGenerated automatically by [gh-refme](https://github.com/https://github.com/metcalfc/gh-refme). Reviews should verify that the pinned commits match the intended references.
