### PR TITLE
Security: Pin GitHub Actions to full commit hashes

### DIFF
--- a/.github/workflows/secure-workflows.yml
+++ b/.github/workflows/secure-workflows.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # was: actions/checkout@v4
         with:
           fetch-depth: 0  # Needed to create PRs
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,7 +24,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # was: actions/checkout@v4
       
       - name: Setup
         run: |
@@ -74,7 +74,7 @@ jobs:
           fi
         
       - name: Upload scan results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was: actions/upload-artifact@v4
         with:
           name: security-scan-results
           path: scan-results/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # was: actions/checkout@v4
       
       - name: Setup test environment
         run: |


### PR DESCRIPTION
# GitHub Actions Security Update

This PR updates GitHub Actions from tags/branches to full commit hashes for improved security.

## Changes Made

| File | Original Reference | Pinned Commit |
|------|-------------------|---------------|
| secure-workflows.yml | actions/checkout@v4 | actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 |
| security-scan.yml | actions/checkout@v4 | actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 |
| security-scan.yml | actions/upload-artifact@v4 | actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 |
| test.yml | actions/checkout@v4 | actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 |

Generated automatically by [gh-refme](https://github.com/metcalfc/gh-refme). Reviews should verify that the pinned commits match the intended references.
