### PR TITLE
Fix: Add explicit permissions to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
This PR fixes a medium severity security vulnerability detected by CodeQL scanning.

## Issue
The test workflow was missing an explicit permissions block, giving the GITHUB_TOKEN default permissions that were broader than necessary.

## Changes
- Added explicit `permissions` block to the test workflow
- Limited permissions to `contents: read`, which is the minimum required for the workflow to function

## Security Impact
This follows the principle of least privilege and reduces the potential attack surface if the workflow were compromised.