### PR TITLE
fix: version release workflow and portable stat command

### DIFF
--- a/gh-refme
+++ b/gh-refme
@@ -8,7 +8,7 @@
 set -e
 
 # Configuration and global variables
-VERSION="1.5.1"
+VERSION="1.6.0"
 TEMP_DIR=$(mktemp -d)
 DRY_RUN=false
 CREATE_BACKUP=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-refme",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "A tool to convert GitHub Actions references to commit hashes for improved security",
   "bin": {
     "gh-refme": "./gh-refme"
@@ -44,7 +44,7 @@
   "files": [
     "gh-refme",
     "lib/",
-    "verify-install.js", 
+    "verify-install.js",
     "README.md",
     "LICENSE",
     "install-hook.sh"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "tests/run-all-tests.sh",
     "postinstall": "node verify-install.js",
     "preversion": "npm test",
-    "postversion": "node -e \"const fs=require('fs'),pkg=require('./package.json');let script=fs.readFileSync('gh-refme','utf8');script=script.replace(/VERSION=\\\"[^\\\"]*\\\"/,'VERSION=\\\"'+pkg.version+'\\\"');fs.writeFileSync('gh-refme',script);\""
+    "version": "node -e \"const fs=require('fs'),pkg=require('./package.json');let script=fs.readFileSync('gh-refme','utf8');script=script.replace(/VERSION=\\\"[^\\\"]*\\\"/,'VERSION=\\\"'+pkg.version+'\\\"');fs.writeFileSync('gh-refme',script);\" && git add gh-refme"
   },
   "repository": {
     "type": "git",

--- a/tests/security-enhancements-test.sh
+++ b/tests/security-enhancements-test.sh
@@ -12,6 +12,15 @@ MAIN_SCRIPT="${SCRIPT_DIR}/../gh-refme"
 # Source common test utilities
 source "${SCRIPT_DIR}/test_utils.sh"
 
+# Portable file permissions (octal) - macOS uses different stat syntax
+get_file_perms() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    stat -f '%A' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
 # Initialize test counters
 init_test_counters
 
@@ -77,22 +86,13 @@ EOF
 
 # Set specific permissions
 chmod 640 "$TEST_FILE"
-# Use portable stat command (macOS vs Linux)
-if [[ "$(uname)" == "Darwin" ]]; then
-  ORIGINAL_PERMS=$(stat -f '%A' "$TEST_FILE")
-else
-  ORIGINAL_PERMS=$(stat -c '%a' "$TEST_FILE")
-fi
+ORIGINAL_PERMS=$(get_file_perms "$TEST_FILE")
 
 # Process the file
 "${MAIN_SCRIPT}" "$TEST_FILE" --dry-run >/dev/null 2>&1 || true
 
 # Check if permissions are preserved
-if [[ "$(uname)" == "Darwin" ]]; then
-  NEW_PERMS=$(stat -f '%A' "$TEST_FILE")
-else
-  NEW_PERMS=$(stat -c '%a' "$TEST_FILE")
-fi
+NEW_PERMS=$(get_file_perms "$TEST_FILE")
 
 if [[ "$ORIGINAL_PERMS" == "$NEW_PERMS" ]]; then
   print_result "File permissions preservation" "pass"


### PR DESCRIPTION
## Summary
- Fix npm version workflow to update `gh-refme` script version BEFORE the commit/tag is created
- Refactor `security-enhancements-test.sh` to use a helper function for portable `stat` command

## Problem
The `postversion` hook ran AFTER npm created the commit and tag, so:
1. Tag pointed to commit with old version in `gh-refme`
2. Script update was uncommitted
3. Required manual commit and force-tag to fix

## Solution
Use `version` hook instead of `postversion`:
- `preversion`: runs tests
- `version`: updates `gh-refme` and stages it (`git add`)
- npm commits both `package.json` and `gh-refme` together
- npm creates tag pointing to correct commit

## Test plan
- [x] `make test` passes
- [ ] Test `npm version patch --dry-run` to verify hook order