### PR TITLE
fix: isolate environment test in subshell to prevent leaks

### DIFF
--- a/gh-refme
+++ b/gh-refme
@@ -8,7 +8,7 @@
 set -e
 
 # Configuration and global variables
-VERSION="1.6.0"
+VERSION="1.6.1"
 TEMP_DIR=$(mktemp -d)
 DRY_RUN=false
 CREATE_BACKUP=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-refme",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A tool to convert GitHub Actions references to commit hashes for improved security",
   "bin": {
     "gh-refme": "./gh-refme"

--- a/tests/security-enhancements-test.sh
+++ b/tests/security-enhancements-test.sh
@@ -123,26 +123,22 @@ print_sub_header "Testing environment security"
 
 # Test 5: Environment variable sanitization
 info_msg "Testing environment variable sanitization..."
-# Set potentially dangerous environment variables
-export IFS=";"
-export PATH=".:$PATH"
-
-# Process a file and verify it works despite dangerous environment
+# Run in subshell to isolate dangerous environment changes
 TEST_FILE="${TEST_DIR}/env-test.yml"
 echo "uses: actions/checkout@v4" > "$TEST_FILE"
 
-OUTPUT=$("${MAIN_SCRIPT}" "$TEST_FILE" --dry-run 2>&1 || true)
+ENV_TEST_OUTPUT=$(
+  export IFS=";"
+  export PATH=".:$PATH"
+  "${MAIN_SCRIPT}" "$TEST_FILE" --dry-run 2>&1 || true
+)
 
-if [[ "$OUTPUT" =~ "Processing" ]] || [[ "$OUTPUT" =~ "Converting" ]]; then
+if [[ "$ENV_TEST_OUTPUT" =~ "Processing" ]] || [[ "$ENV_TEST_OUTPUT" =~ "Converting" ]]; then
   print_result "Environment sanitization" "pass"
 else
-  print_result "Environment sanitization" "fail" "Failed with dangerous environment: $OUTPUT"
+  print_result "Environment sanitization" "fail" "Failed with dangerous environment: $ENV_TEST_OUTPUT"
   exit 1
 fi
-
-# Clean up environment
-unset IFS
-export PATH="${PATH#.:}"
 
 # Test 6: Valid references still work with security enhancements
 info_msg "Testing valid references still work with security..."


### PR DESCRIPTION
## Summary
Run the dangerous environment test (IFS/PATH modification) in a subshell to prevent environment pollution if the test fails.

## Problem
The test modified `IFS` and `PATH` globally, with cleanup at the end. If `set -e` caused an early exit, the cleanup wouldn't run, leaving the environment polluted for subsequent tests.

## Solution
Capture output from a subshell where the dangerous environment is set. The subshell isolates the changes automatically.

## Test plan
- [x] `./tests/security-enhancements-test.sh` passes