### PR TITLE
fix: library improvements for portability and robustness

### DIFF
--- a/gh-refme
+++ b/gh-refme
@@ -125,14 +125,16 @@ process_directory() {
   # Find workflow files (yml or yaml)
   local workflow_files
   workflow_files=$(find "$workflow_dir" -type f \( -name "*.yml" -o -name "*.yaml" \))
-  local file_count
-  file_count=$(echo "$workflow_files" | wc -l | tr -d ' ')
-  
-  if [[ -z "$workflow_files" || "$file_count" -eq 0 ]]; then
+
+  if [[ -z "$workflow_files" ]]; then
     echo "No workflow files found in $workflow_dir"
     return 0
   fi
-  
+
+  # Count files (only if non-empty to avoid wc counting empty line)
+  local file_count
+  file_count=$(printf '%s\n' "$workflow_files" | grep -c .)
+
   echo "Found $file_count workflow files"
   
   # Process each workflow file

--- a/lib/gh-refme-lib.sh
+++ b/lib/gh-refme-lib.sh
@@ -491,15 +491,19 @@ process_single_reference() {
 secure_copy_file() {
   local source_file="$1"
   local dest_file="$2"
-  
+
   # Validate both file paths
   if ! validate_file_path_security "$source_file" || ! validate_file_path_security "$dest_file"; then
     return 1
   fi
-  
-  # Get original file permissions
+
+  # Get original file permissions (portable across macOS and Linux)
   local orig_perms
-  orig_perms=$(stat -c '%a' "$dest_file" 2>/dev/null || echo "644")
+  if [[ "$(uname)" == "Darwin" ]]; then
+    orig_perms=$(stat -f '%A' "$dest_file" 2>/dev/null || echo "644")
+  else
+    orig_perms=$(stat -c '%a' "$dest_file" 2>/dev/null || echo "644")
+  fi
   
   # Copy content securely
   if cp "$source_file" "$dest_file"; then

--- a/lib/gh-refme-lib.sh
+++ b/lib/gh-refme-lib.sh
@@ -570,16 +570,26 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
+# Escape sed metacharacters in pattern (BRE)
+escape_sed_pattern() {
+  printf '%s' "$1" | sed 's/[[\.*^$()|]/\\&/g'
+}
+
+# Escape sed metacharacters in replacement string
+escape_sed_replacement() {
+  printf '%s' "$1" | sed 's/[&|\\]/\\&/g'
+}
+
 # Create a valid sed in-place edit command (compatible with BSD and GNU sed)
 sed_in_place() {
   local file="$1"
   local pattern="$2"
   local replacement="$3"
-  
-  # Remove any trailing newlines from pattern and replacement
-  pattern=$(echo -n "$pattern" | tr -d '\n')
-  replacement=$(echo -n "$replacement" | tr -d '\n')
-  
+
+  # Escape sed metacharacters for safe substitution
+  pattern=$(escape_sed_pattern "$pattern")
+  replacement=$(escape_sed_replacement "$replacement")
+
   # Check if we're using BSD or GNU sed
   if sed --version 2>/dev/null | grep -q "GNU"; then
     # GNU sed


### PR DESCRIPTION
## Summary
Three targeted fixes for real issues found during code review.

### Commits

1. **fix: use portable stat command in secure_copy_file for macOS**
   - `--backup` flag was broken on macOS due to `stat -c` (Linux-only)
   - Now uses `stat -f '%A'` on Darwin, `stat -c '%a'` on Linux

2. **fix: escape sed metacharacters in pattern and replacement**
   - Prevents unexpected behavior if references contain `.`, `*`, `&`, `|`, etc.
   - Uses `printf` instead of `echo -n` for better portability

3. **fix: correct workflow file count when directory is empty**
   - `echo | wc -l` reports 1 even for empty string (due to trailing newline)
   - Now checks for empty first, then counts with `grep -c`

## Test plan
- [x] All existing tests pass (`make test`)
- [x] ShellCheck passes