### PR TITLE
fix: harden workflows and enable strict bash mode

### DIFF
--- a/.github/workflows/secure-workflows.yml
+++ b/.github/workflows/secure-workflows.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
     
     steps:
       - name: Checkout code
@@ -33,13 +32,9 @@ jobs:
           
       - name: Run gh-refme
         run: |
-          # Get a release of gh-refme
-          curl -sL -o /usr/local/bin/gh-refme https://raw.githubusercontent.com/metcalfc/gh-refme/refs/tags/v1.5.0/gh-refme
-          chmod +x /usr/local/bin/gh-refme
-          
-          # Run gh-refme and capture all output for reference
+          # Run gh-refme from the checked-out repo and capture all output
           echo "Running gh-refme on workflow files..."
-          gh-refme .github/workflows/*.{yml,yaml} 2>&1 | tee refme_output.log
+          ./gh-refme .github/workflows/*.{yml,yaml} 2>&1 | tee refme_output.log
           
           # Check if any changes were made
           if git diff --quiet; then

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,18 +18,12 @@ jobs:
     # Skip this job if the branch name starts with gh-refme-secure-
     if: "!startsWith(github.head_ref, 'gh-refme-secure-')"
     permissions:
-      contents: write
-      pull-requests: write
-      actions: write
+      contents: read
+      pull-requests: read
     
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # was: actions/checkout@v4
-      
-      - name: Setup
-        run: |
-          curl -sL -o /usr/local/bin/gh-refme https://raw.githubusercontent.com/metcalfc/gh-refme/refs/tags/v1.5.0/gh-refme
-          chmod +x /usr/local/bin/gh-refme
       
       - name: Validate workflow files
         env:
@@ -58,7 +52,7 @@ jobs:
               sed '/^[[:space:]]*#/d' "$file" > "$TEMP_FILE"
               
               # Run in dry-run mode to check for references without changing files
-              gh-refme --dry-run "$TEMP_FILE" > "scan-results/$(basename "$file").log" 2>&1
+              ./gh-refme --dry-run "$TEMP_FILE" > "scan-results/$(basename "$file").log" 2>&1
               
               # Check for branch or tag references (excluding comments)
               if grep -q "Updated " "scan-results/$(basename "$file").log"; then

--- a/gh-refme
+++ b/gh-refme
@@ -5,7 +5,7 @@
 # This script processes GitHub Actions workflow YAML files and converts
 # git references (tags, branches, short commits) to full commit hashes.
 #
-set -e
+set -euo pipefail
 
 # Configuration and global variables
 VERSION="1.6.1"
@@ -27,7 +27,7 @@ fi
 sanitize_environment
 
 # Detect if being run as a GitHub CLI extension
-if [[ -n "$GH_CLI_VERSION" ]]; then
+if [[ -n "${GH_CLI_VERSION:-}" ]]; then
   CMD_NAME="gh refme"
 else
   CMD_NAME="gh-refme"

--- a/lib/gh-refme-lib.sh
+++ b/lib/gh-refme-lib.sh
@@ -82,7 +82,7 @@ validate_file_path_security() {
 # Check if string contains dangerous shell characters
 has_dangerous_chars() {
   local string="$1"
-  echo "$string" | grep -q '[\\$`;(){}|&<>!#]'
+  printf '%s\n' "$string" | grep -q '[\\$`;(){}|&<>!#]'
 }
 
 # Enhanced security validation for references
@@ -243,7 +243,7 @@ get_github_token() {
   fi
   
   # Then try environment variable
-  if [[ -n "${GITHUB_TOKEN}" ]]; then
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
     echo "${GITHUB_TOKEN}"
     return 0
   fi
@@ -458,9 +458,9 @@ process_github_references() {
       local ref="${BASH_REMATCH[1]}"
       
       # Check if previous line had "refme: ignore" comment
-      if [[ -n "$prev_comment" && "$prev_comment" =~ refme:[[:space:]]*ignore ]]; then
+      if [[ -n "${prev_comment:-}" && "$prev_comment" =~ refme:[[:space:]]*ignore ]]; then
         echo "Skipping $ref (refme: ignore)"
-        unset prev_comment
+        prev_comment=""
         continue
       fi
       
@@ -517,16 +517,16 @@ process_single_reference() {
     local hash
     if hash=$(get_commit_hash "$owner" "$repo" "$reference" 2>/dev/null); then
       # Optionally add a tag to the comment
-      local tag
+      local tag=""
       if [[ "$show_tag" == "true" ]]; then
-        tag=$(get_tag_for_commit "$owner" "$repo" "$hash" 2>/dev/null)
+        tag=$(get_tag_for_commit "$owner" "$repo" "$hash" 2>/dev/null) || true
       fi
 
       # Replace in the temp file with a comment showing the original reference
       local old_pattern="uses: ${ref}"
 
       local new_pattern
-      if [[ -n "$tag" ]]; then
+      if [[ -n "${tag}" ]]; then
         new_pattern="uses: ${owner}/${repo}@${hash} # was: ${ref} (${tag})"
       else
         new_pattern="uses: ${owner}/${repo}@${hash} # was: ${ref}"


### PR DESCRIPTION
## Summary

### Workflows
- Use `./gh-refme` from checkout instead of `curl` from a mutable tag — ironic for a security tool to download itself via a mutable reference
- Drop unnecessary `actions: write` permission from secure-workflows and security-scan
- Downgrade security-scan permissions to read-only (it only reads and uploads artifacts)

### Script
- Enable `set -euo pipefail` (was just `set -e`)
- Fix unbound variable errors for `set -u` compatibility (`GH_CLI_VERSION`, `GITHUB_TOKEN`, `prev_comment`, `tag`)
- Use `printf` instead of `echo` for untrusted input in `has_dangerous_chars`

## Test plan
- [x] All 66 tests pass
- [x] ShellCheck clean
- [x] `./gh-refme --version` works
- [x] `./gh-refme --dry-run .github/workflows/*.yml` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)